### PR TITLE
Fix about page showing desktop layout on iPad landscape

### DIFF
--- a/assets/css/rawr-theme.css
+++ b/assets/css/rawr-theme.css
@@ -647,7 +647,7 @@ button { font-family: inherit; }
 
 /* ===== About Page ===== */
 
-/* Show/hide layouts: desktop ≥1101px, tablet 768-1100px, mobile ≤767px */
+/* Show/hide layouts: desktop ≥1201px, tablet 768-1200px, mobile ≤767px */
 .about-desktop { display: grid; grid-template-columns: 260px 1fr 280px; gap: 2rem; padding: 3rem 0 4rem; align-items: start; }
 .about-tablet  { display: none; }
 .about-mobile  { display: none; }
@@ -1545,8 +1545,8 @@ button { font-family: inherit; }
   .rawr-search:focus { width: 190px; }
 }
 
-/* Tablet about layout (768–1100px) */
-@media (min-width: 768px) and (max-width: 1100px) {
+/* Tablet about layout (768–1200px, covers iPad landscape at 1180px) */
+@media (min-width: 768px) and (max-width: 1200px) {
   .about-desktop { display: none; }
   .about-tablet  { display: grid; }
 }


### PR DESCRIPTION
Extend the tablet breakpoint from 1100px to 1200px so that iPad in landscape mode (1180px viewport) uses the two-column tablet layout instead of the cramped three-column desktop layout.


Claude-Session: https://claude.ai/code/session_01ASrgXKBQ21zcxQcm8WutZt