### PR TITLE
Fix navigation overflow on iPad portrait (820px viewport)

### DIFF
--- a/assets/css/rawr-theme.css
+++ b/assets/css/rawr-theme.css
@@ -1543,15 +1543,8 @@ button { font-family: inherit; }
   .hero-inner { grid-template-columns: 1fr 280px; }
   .rawr-search { width: 150px; }
   .rawr-search:focus { width: 190px; }
-}
 
-/* Tablet about layout (768–1200px, covers iPad landscape at 1180px) */
-@media (min-width: 768px) and (max-width: 1200px) {
-  .about-desktop { display: none; }
-  .about-tablet  { display: grid; }
-}
-
-@media (max-width: 768px) {
+  /* Hamburger nav — 7 links don't fit below 1024px */
   .rawr-nav-links {
     display: none;
     position: fixed;
@@ -1564,10 +1557,18 @@ button { font-family: inherit; }
     z-index: 999;
     box-shadow: 0 8px 24px rgba(0,0,0,0.3);
   }
-
   .rawr-nav-links.open { display: flex; }
   .rawr-nav-link { padding: 0.6rem 1rem; font-size: 0.95rem; }
   .rawr-nav-toggle { display: flex; }
+}
+
+/* Tablet about layout (768–1200px, covers iPad landscape at 1180px) */
+@media (min-width: 768px) and (max-width: 1200px) {
+  .about-desktop { display: none; }
+  .about-tablet  { display: grid; }
+}
+
+@media (max-width: 768px) {
   .rawr-nav-actions { display: none; }
 
   .hero-inner { grid-template-columns: 1fr; }


### PR DESCRIPTION
Move hamburger nav trigger from max-width 768px to 1024px so that iPad portrait (820px) collapses the 7 nav links into a hamburger menu instead of overflowing the nav bar.


Claude-Session: https://claude.ai/code/session_01ASrgXKBQ21zcxQcm8WutZt